### PR TITLE
Remove unused units package

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -5,7 +5,6 @@
 \usepackage{epsfig} % Allows the inclusion of eps files
 \usepackage{epic} % Enhanced picture mode
 \usepackage{eepic} % Extensions for epic
-\usepackage{units} % SI unit typesetting
 \usepackage{url} % URL handling
 \usepackage{longtable} % Tables that continue onto multiple pages
 \usepackage{mathrsfs} % Support for \mathscr script


### PR DESCRIPTION
It was causing a build error:

```
! Package siunitx Error: Package 'units' incompatible.

For immediate help type H <return>.
 ...

l.57   \__siunitx_load_check:n

?
! Emergency stop.
 ...

l.57   \__siunitx_load_check:n

!  ==> Fatal error occurred, no output PDF file produced!
```